### PR TITLE
Infinity and early conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,3 @@ os:
 language: node_js
 node_js:
   - node
-  - '6'
-  - '4'
-  - '0.12'
-  - '0.10'

--- a/index.js
+++ b/index.js
@@ -43,6 +43,9 @@ function repeat(str, num) {
     throw new TypeError('expected a string');
   }
 
+  // no need to repeat an empty string
+  if (str === '') return '';
+
   // cover common, quick use cases
   if (num === 1) return str;
   if (num === 2) return str + str;

--- a/index.js
+++ b/index.js
@@ -51,6 +51,11 @@ function repeat(str, num) {
   if (num === 2) return str + str;
 
   var max = str.length * num;
+
+  if (max === Infinity) {
+    throw new TypeError('cannot repeat indefinitely');
+  }
+
   if (cache !== str || typeof cache === 'undefined') {
     cache = str;
     res = '';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "benchmarked": "^0.2.5",
     "gulp-format-md": "^0.1.11",
     "isobject": "^2.1.0",
-    "mocha": "^3.1.2",
+    "mocha": "^8.3.2",
     "repeating": "^3.0.0",
     "text-table": "^0.2.0",
     "yargs-parser": "^4.0.2"

--- a/test.js
+++ b/test.js
@@ -8,9 +8,9 @@
 'use strict';
 
 require('mocha');
-var assert = require('assert');
+const assert = require('assert');
 const { it } = require('mocha');
-var repeat = require('./');
+const repeat = require('./');
 
 describe('repeat', function() {
   it('should return an empty string when a number is not given:', function() {

--- a/test.js
+++ b/test.js
@@ -72,4 +72,11 @@ describe('repeat', function() {
     assert.throws(function() {repeat(10); }, /expected a string/);
     assert.throws(function() {repeat(null); }, /expected a string/);
   });
+
+  it('should throw an error when attempting to repeat ad infinitum', function () {
+    assert.throws(function () { repeat('foo', Infinity); });
+    assert.throws(function () { repeat('foo', 'Infinity'); });
+    assert.doesNotThrow(function () { repeat('foo', -Infinity); });
+    assert.doesNotThrow(function () { repeat('foo', '-Infinity'); });
+  });
 });

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@
 
 require('mocha');
 var assert = require('assert');
+const { it } = require('mocha');
 var repeat = require('./');
 
 describe('repeat', function() {
@@ -21,6 +22,11 @@ describe('repeat', function() {
     assert.equal(repeat('a', 0), '');
     assert.equal(repeat('', null), '');
     assert.equal(repeat('a', null), '');
+  });
+
+  it('shoud not round numbers:', function() {
+    assert.equal(repeat('A', 6.9), repeat('A', 6));
+    assert.equal(repeat('A', '6.9'), repeat('A', 6));
   });
 
   it('should repeat the given string n times', function() {

--- a/test.js
+++ b/test.js
@@ -29,6 +29,13 @@ describe('repeat', function() {
     assert.equal(repeat('A', '6.9'), repeat('A', 6));
   });
 
+  it('should return an empty string for negative numbers:', function () {
+    assert.equal(repeat('A', -42), '');
+    assert.equal(repeat('A', '-42'), '');
+    assert.equal(repeat('A', -Infinity), '');
+    assert.equal(repeat('A', '-Infinity'), '');
+  });
+
   it('should repeat the given string n times', function() {
     assert.equal(repeat(' ', 0), '');
     assert.equal(repeat('a', 0), '');


### PR DESCRIPTION
This pull request has a few things going on:

1. Mocha was a bit out of date. Upgraded it but that meant having to stop testing on Node.js 6 and below. These versions of Node.js aren't supported anymore so probably not a big deal anyway.
2. Added a few missing tests: numbers aren't rounded _and_ negative numbers produce empty strings
3. There were `var` _and_ `const`. No need to have both so replaced with `const`.
4. Early exit condition when the string to repeat is empty
5. Breaking change: can't repeat a string when number is `Infinity`

**Infinity**

The native `String#repeat` method does throw an error when `Infinity` is given as a parameter. So this changes aligns with the native behaviour. Also there's an issue with how `Infinity` works right now: with the same string to repeat, it will produce a _different_ string:

```
const repeat = require('repeat-string');

repeat('🌯', Infinity)
//=> '🌯🌯'
repeat('🌯', Infinity)
//=> '🌯🌯🌯🌯'
repeat('🌯', Infinity)
//=> '🌯🌯🌯🌯🌯🌯' 
```

This didn't seem right to me so took the liberty to throw an error instead.